### PR TITLE
fix: add link from navbar title to homepage

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,7 +20,11 @@ function App() {
 
   return (
     <div style={{ padding: "1.5rem", fontFamily: "system-ui" }}>
-      <h1>Coastal Risk Portal – Upcoming Renewals</h1>
+      <h1>
+        <a href="/" style={{ textDecoration: "none", color: "inherit" }}>
+          Coastal Risk Portal – Upcoming Renewals
+        </a>
+      </h1>
 
       <label>
         Days to expiration:{" "}


### PR DESCRIPTION
Wrapped the h1 title in an anchor tag that links to the root path, allowing users to click the title to return to the homepage/dashboard.

Fixes #2

---
Generated with [Claude Code](https://claude.ai/code)